### PR TITLE
Fix SemanticKernel Vector Search

### DIFF
--- a/src/cosmos-copilot.WebApp/Models/Product.cs
+++ b/src/cosmos-copilot.WebApp/Models/Product.cs
@@ -19,12 +19,13 @@ namespace Cosmos.Copilot.Models
         public string description { get; set; }
         [VectorStoreRecordData]
         public double price { get; set; }
-        [VectorStoreRecordData]
+        //[VectorStoreRecordData]
         public List<Tag> tags { get; set; }
-        [VectorStoreRecordVector(Dimensions: 1536, DistanceFunction: DistanceFunction.CosineSimilarity, IndexKind: IndexKind.DiskAnn)]
-        public float[]? vectors { get; set; }
 
-        public Product(string id, string categoryId, string categoryName, string sku, string name, string description, double price, List<Tag> tags, float[]? vectors = null)
+        [VectorStoreRecordVector(Dimensions: 1536, DistanceFunction: DistanceFunction.CosineSimilarity, IndexKind: IndexKind.DiskAnn)]
+        public ReadOnlyMemory<float>? vectors { get; set; }
+
+        public Product(string id, string categoryId, string categoryName, string sku, string name, string description, double price, List<Tag> tags, ReadOnlyMemory<float>? vectors = null)
         {
             this.id = id;
             this.categoryId = categoryId;

--- a/src/cosmos-copilot.WebApp/Program.cs
+++ b/src/cosmos-copilot.WebApp/Program.cs
@@ -44,18 +44,18 @@ builder.AddAzureCosmosClient(
         };
     });
 
-//// Configure OpenAI Aspire integration
-//var openAIEndpoint = builder.Configuration.GetSection(nameof(OpenAi)).GetValue<string>("Endpoint");
-//if (openAIEndpoint is null)
-//{
-//    throw new ArgumentException($"{nameof(IOptions<OpenAi>)} was not resolved through dependency injection.");
-//}
-//builder.AddAzureOpenAIClient("openAiConnectionName",
-//    configureSettings: settings =>
-//    {
-//        settings.Endpoint = new Uri(openAIEndpoint);
-//        settings.Credential = new DefaultAzureCredential();
-//    });
+// Configure OpenAI Aspire integration
+var openAIEndpoint = builder.Configuration.GetSection(nameof(OpenAi)).GetValue<string>("Endpoint");
+if (openAIEndpoint is null)
+{
+    throw new ArgumentException($"{nameof(IOptions<OpenAi>)} was not resolved through dependency injection.");
+}
+builder.AddAzureOpenAIClient("openAiConnectionName",
+    configureSettings: settings =>
+    {
+        settings.Endpoint = new Uri(openAIEndpoint);
+        settings.Credential = new DefaultAzureCredential();
+    });
 
 builder.Services.RegisterServices();
 

--- a/src/cosmos-copilot.WebApp/Program.cs
+++ b/src/cosmos-copilot.WebApp/Program.cs
@@ -3,6 +3,7 @@ using Cosmos.Copilot.Options;
 using Cosmos.Copilot.Services;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,9 +30,9 @@ builder.AddAzureCosmosClient(
     },
     clientOptions => {
         clientOptions.ApplicationName = "cosmos-copilot";
-        clientOptions.SerializerOptions = new()
+        clientOptions.UseSystemTextJsonSerializerWithOptions = new JsonSerializerOptions()
         {
-            PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
         clientOptions.CosmosClientTelemetryOptions = new()
         {
@@ -43,18 +44,18 @@ builder.AddAzureCosmosClient(
         };
     });
 
-// Configure OpenAI Aspire integration
-var openAIEndpoint = builder.Configuration.GetSection(nameof(OpenAi)).GetValue<string>("Endpoint");
-if (openAIEndpoint is null)
-{
-    throw new ArgumentException($"{nameof(IOptions<OpenAi>)} was not resolved through dependency injection.");
-}
-builder.AddAzureOpenAIClient("openAiConnectionName",
-    configureSettings: settings =>
-    {
-        settings.Endpoint = new Uri(openAIEndpoint);
-        settings.Credential = new DefaultAzureCredential();
-    });
+//// Configure OpenAI Aspire integration
+//var openAIEndpoint = builder.Configuration.GetSection(nameof(OpenAi)).GetValue<string>("Endpoint");
+//if (openAIEndpoint is null)
+//{
+//    throw new ArgumentException($"{nameof(IOptions<OpenAi>)} was not resolved through dependency injection.");
+//}
+//builder.AddAzureOpenAIClient("openAiConnectionName",
+//    configureSettings: settings =>
+//    {
+//        settings.Endpoint = new Uri(openAIEndpoint);
+//        settings.Credential = new DefaultAzureCredential();
+//    });
 
 builder.Services.RegisterServices();
 

--- a/src/cosmos-copilot.WebApp/cosmos-copilot.WebApp.csproj
+++ b/src/cosmos-copilot.WebApp/cosmos-copilot.WebApp.csproj
@@ -10,9 +10,9 @@
     <None Include="Shared\MainLayout.razor" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="8.2.0-preview.1.24428.5" />
+    <PackageReference Include="Aspire.Azure.AI.OpenAI" Version="9.0.0-preview.4.24511.1" />
     <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="8.2.0" />
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.0" />
     <PackageReference Include="Humanizer" Version="2.*" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.0-preview.1" />


### PR DESCRIPTION
Fixes
- SK Cosmos vector search doesn't support custom types so `List<Tag> tag` can't have the `[VectorStoreRecordData]` attribute [ref](https://learn.microsoft.com/en-us/semantic-kernel/concepts/vector-store-connectors/out-of-the-box-connectors/azure-cosmosdb-nosql-connector?pivots=programming-language-csharp#overview)
- SK Cosmos vector search vector property type must be `ReadOnlyMemory` [ref](https://learn.microsoft.com/en-us/semantic-kernel/concepts/vector-store-connectors/out-of-the-box-connectors/azure-cosmosdb-nosql-connector?pivots=programming-language-csharp#overview)
- Updated CosmosClient to use `System.Text.Json` to fix serializer errors
- Updated OpenAI Aspire integration