### PR TITLE
fix query, delete by pk

### DIFF
--- a/infra/app/database.bicep
+++ b/infra/app/database.bicep
@@ -30,6 +30,9 @@ var containers = [
           path: '/sessionId/?'
         }
         {
+          path: '/type/?'
+        }
+        {
           path: '/timeStamp/?'
         }
       ]
@@ -60,9 +63,7 @@ var containers = [
         }
       ]
       excludedPaths: [
-        {
-          path: '/vectors/?'
-        }
+        
       ]
       vectorIndexes: [
         {

--- a/src/cosmos-copilot.WebApp/Services/CosmosDbService.cs
+++ b/src/cosmos-copilot.WebApp/Services/CosmosDbService.cs
@@ -148,7 +148,7 @@ public class CosmosDbService
         PartitionKey partitionKey = GetPK(tenantId, userId, string.Empty);
 
         QueryDefinition query = new QueryDefinition(
-            "SELECT DISTINCT * FROM c WHERE c.type = @type"
+            "SELECT * FROM c WHERE c.type = @type"
         ).WithParameter("@type", nameof(Session));
 
         FeedIterator<Session> response = _chatContainer.GetItemQueryIterator<Session>(
@@ -335,7 +335,19 @@ public class CosmosDbService
     {
         PartitionKey partitionKey = GetPK(tenantId, userId, sessionId);
 
-        await _chatContainer.DeleteAllItemsByPartitionKeyStreamAsync(partitionKey);
+        //This only works if Delete By Partition key feature is enabled on the account
+        //await _chatContainer.DeleteAllItemsByPartitionKeyStreamAsync(partitionKey);
+
+        //This is a workaround to delete all items in a partition without this feature above
+        List<Message> messages = await GetSessionMessagesAsync(tenantId, userId, sessionId);
+
+        foreach (var message in messages)
+        {
+            await _chatContainer.DeleteItemAsync<Message>(
+                partitionKey: partitionKey,
+                id: message.Id
+            );
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fix bicep, add type property to index path
Fix query, remove distinct from GetSessionsAsync()
Fix delete by partition key. Feature is no longer enabled by default for new accounts.