### PR TITLE
Deployment failure - API version fix for vectorEmbeddingPolicy

### DIFF
--- a/infra/core/database/cosmos-db/account.bicep
+++ b/infra/core/database/cosmos-db/account.bicep
@@ -17,7 +17,7 @@ param enableNoSQLVectorSearch bool = false
 @description('Disables key-based authentication. Defaults to false.')
 param disableKeyBasedAuth bool = false
 
-resource account 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
+resource account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   name: name
   location: location
   tags: tags

--- a/infra/core/database/cosmos-db/nosql/container.bicep
+++ b/infra/core/database/cosmos-db/nosql/container.bicep
@@ -41,16 +41,16 @@ var options = setThroughput
         }
   : {}
 
-resource account 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' existing = {
+resource account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
   name: parentAccountName
 }
 
-resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15' existing = {
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-11-15' existing = {
   name: parentDatabaseName
   parent: account
 }
 
-resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = {
   name: name
   parent: database
   tags: tags

--- a/infra/core/database/cosmos-db/nosql/database.bicep
+++ b/infra/core/database/cosmos-db/nosql/database.bicep
@@ -27,11 +27,11 @@ var options = setThroughput
         }
   : {}
 
-resource account 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' existing = {
+resource account 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
   name: parentAccountName
 }
 
-resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15' = {
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-11-15' = {
   name: name
   parent: account
   tags: tags


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Updates API version from 2024-05-15 to 2024-11-15 as the deployment of some Azure resources now fails. Specifically fails on:
    * 'database'
        * 'cosmos-db-container-products'
        * 'cosmos-db-container-cache'
        * 'cosmos-db-container-chat'
* Error: "Property vectorEmbeddingPolicy is not supported with API Version: 2024-05-15. Please use API Version: 2024-11-15"
* Deployed successfully with the change.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
